### PR TITLE
feat: add TimeStampedModel abstract base model

### DIFF
--- a/inventory/models.py
+++ b/inventory/models.py
@@ -1,0 +1,19 @@
+from django.conf import settings
+from django.db import models
+
+
+class TimeStampedModel(models.Model):
+    """Audit fields inherited by all inventory models."""
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="%(class)s_created",
+    )
+
+    class Meta:
+        abstract = True


### PR DESCRIPTION
Closes #4

Add a reusable abstract base model that provides consistent audit fields for all inventory models. Every concrete model in the inventory app will inherit from TimeStampedModel.

Fields:
- created_at: DateTimeField (auto_now_add) — set once on creation
- updated_at: DateTimeField (auto_now) — updated on every save
- created_by: FK → AUTH_USER_MODEL (SET_NULL, nullable) — tracks who created the record; uses %(class)s_created related_name pattern to avoid reverse accessor clashes across child models

Notes:
- Abstract model — no database table or migration generated
- Depends on: #3 (inventory app scaffold)
- Blocks: #5, #7, #10, #11, #13, #15, #17 (all concrete models)