### PR TITLE
feat: add low-stock alerts view and filtering

### DIFF
--- a/inventory/filters.py
+++ b/inventory/filters.py
@@ -1,0 +1,65 @@
+"""Django-filter filtersets for inventory models.
+
+Each filterset is a class following the project's OOP standard.
+"""
+
+import django_filters
+
+from inventory.models import Category, Product, StockLocation
+
+
+class StockStatusFilter(django_filters.ChoiceFilter):
+    """Custom filter for stock-level status (low / in-stock / out-of-stock)."""
+
+    STATUS_CHOICES = [
+        ("", "All"),
+        ("low", "Low Stock"),
+        ("in_stock", "In Stock"),
+        ("out_of_stock", "Out of Stock"),
+    ]
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("choices", self.STATUS_CHOICES)
+        kwargs.setdefault("label", "Stock Status")
+        super().__init__(*args, **kwargs)
+
+    def filter(self, qs, value):
+        if value == "low":
+            return qs.low_stock()
+        elif value == "in_stock":
+            return qs.in_stock()
+        elif value == "out_of_stock":
+            return qs.out_of_stock()
+        return qs
+
+
+class ProductFilterSet(django_filters.FilterSet):
+    """Filterset for Product listings with stock-aware filters.
+
+    Provides filters for:
+    - **category** — FK dropdown
+    - **stock_status** — custom filter using ProductQuerySet methods
+    - **is_active** — boolean
+    - **location** — filters products that have stock at a given location
+    """
+
+    category = django_filters.ModelChoiceFilter(
+        queryset=Category.objects.all(),
+        label="Category",
+        empty_label="All Categories",
+    )
+    stock_status = StockStatusFilter(field_name="stock_status")
+    is_active = django_filters.BooleanFilter(
+        label="Active",
+    )
+    location = django_filters.ModelChoiceFilter(
+        field_name="stock_records__location",
+        queryset=StockLocation.objects.all(),
+        label="Location",
+        empty_label="All Locations",
+        distinct=True,
+    )
+
+    class Meta:
+        model = Product
+        fields = ["category", "stock_status", "is_active", "location"]

--- a/inventory/models/__init__.py
+++ b/inventory/models/__init__.py
@@ -1,6 +1,6 @@
 from .base import TimeStampedModel
 from .category import Category
-from .product import Product, ProductImage, ProductTag, UnitOfMeasure
+from .product import Product, ProductImage, ProductQuerySet, ProductTag, UnitOfMeasure
 from .stock import MovementType, StockLocation, StockMovement, StockRecord
 
 __all__ = [
@@ -9,6 +9,7 @@ __all__ = [
     "MovementType",
     "Product",
     "ProductImage",
+    "ProductQuerySet",
     "ProductTag",
     "StockLocation",
     "StockMovement",

--- a/inventory/models/product.py
+++ b/inventory/models/product.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.db.models import F
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
@@ -19,6 +20,32 @@ class UnitOfMeasure(models.TextChoices):
     METERS = "m", "Meters"
     BOXES = "box", "Boxes"
     PACKS = "pack", "Packs"
+
+
+class ProductQuerySet(models.QuerySet):
+    """Custom queryset with inventory-specific filters."""
+
+    def low_stock(self):
+        """Return products where any StockRecord quantity <= reorder_point.
+
+        Products with ``reorder_point = 0`` are excluded (no alert configured).
+        """
+        return self.filter(
+            reorder_point__gt=0,
+            stock_records__quantity__lte=F("reorder_point"),
+        ).distinct()
+
+    def out_of_stock(self):
+        """Return products that have at least one StockRecord with quantity 0."""
+        return self.filter(
+            stock_records__quantity=0,
+        ).distinct()
+
+    def in_stock(self):
+        """Return products where all StockRecords are above reorder_point."""
+        return self.exclude(
+            pk__in=self.low_stock().values_list("pk", flat=True),
+        ).filter(stock_records__quantity__gt=0).distinct()
 
 
 @register_snippet
@@ -58,6 +85,8 @@ class Product(TimeStampedModel, ClusterableModel):
         through="inventory.ProductTag",
         blank=True,
     )
+
+    objects = ProductQuerySet.as_manager()
 
     panels = [
         FieldPanel("sku"),

--- a/inventory/templates/inventory/low_stock_alerts.html
+++ b/inventory/templates/inventory/low_stock_alerts.html
@@ -1,0 +1,104 @@
+{% extends "wagtailadmin/generic/base.html" %}
+{% load wagtailadmin_tags i18n %}
+
+{% block main_content %}
+<div class="w-mb-4">
+    <p>
+        Showing <strong>{{ total_count }}</strong> product{{ total_count|pluralize }}
+        at or below their reorder point.
+    </p>
+</div>
+
+{# ── Filters ── #}
+<form method="get" class="w-mb-6">
+    <div style="display: flex; gap: 1rem; flex-wrap: wrap; align-items: flex-end;">
+        {% for field in filterset.form %}
+        <div>
+            <label for="{{ field.id_for_label }}" class="w-label">{{ field.label }}</label>
+            {{ field }}
+        </div>
+        {% endfor %}
+        <div>
+            <button type="submit" class="button button-small">Filter</button>
+            <a href="{% url 'inventory_low_stock' %}" class="button button-small button-secondary">Clear</a>
+        </div>
+    </div>
+</form>
+
+{# ── Results table ── #}
+{% if products %}
+<table class="listing">
+    <thead>
+        <tr>
+            <th>SKU</th>
+            <th>Product</th>
+            <th>Category</th>
+            <th>Reorder Point</th>
+            <th>Stock Details</th>
+            <th>Status</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for product in products %}
+        <tr>
+            <td>
+                <a href="{% url 'wagtailsnippets_inventory_product:edit' product.pk %}">
+                    {{ product.sku }}
+                </a>
+            </td>
+            <td>{{ product.name }}</td>
+            <td>{{ product.category|default:"—" }}</td>
+            <td>{{ product.reorder_point }}</td>
+            <td>
+                {% for record in product.stock_records.all %}
+                    <div>
+                        {{ record.location.name }}:
+                        <strong{% if record.is_low_stock %} style="color: var(--w-color-critical-200);"{% endif %}>
+                            {{ record.quantity }}
+                        </strong>
+                    </div>
+                {% empty %}
+                    <em>No stock records</em>
+                {% endfor %}
+            </td>
+            <td>
+                {% for record in product.stock_records.all %}
+                    {% if record.quantity == 0 %}
+                        <span class="w-status w-status--primary">Out of Stock</span>
+                    {% elif record.is_low_stock %}
+                        <span class="w-status w-status--primary">Low</span>
+                    {% endif %}
+                {% endfor %}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+{# ── Pagination ── #}
+{% if is_paginated %}
+<div class="pagination">
+    {% if page_obj.has_previous %}
+        <a href="?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_obj.previous_page_number }}"
+           class="button button-small">
+            &laquo; Previous
+        </a>
+    {% endif %}
+
+    <span class="w-label" style="padding: 0 1rem;">
+        Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+    </span>
+
+    {% if page_obj.has_next %}
+        <a href="?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_obj.next_page_number }}"
+           class="button button-small">
+            Next &raquo;
+        </a>
+    {% endif %}
+</div>
+{% endif %}
+
+{% else %}
+<p>{% trans "No low-stock products found." %}</p>
+{% endif %}
+{% endblock %}

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1,0 +1,38 @@
+"""Inventory views for the Wagtail admin.
+
+All views follow the project's OOP standard — class-based with
+WagtailAdminTemplateMixin for consistent admin chrome.
+"""
+
+from django.views.generic import ListView
+from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
+
+from inventory.filters import ProductFilterSet
+from inventory.models import Product
+
+
+class LowStockAlertView(WagtailAdminTemplateMixin, ListView):
+    """Display products that are at or below their reorder point.
+
+    Integrates with the Wagtail admin shell (header, breadcrumbs, sidebar
+    highlight) and uses :class:`ProductFilterSet` for filtering by
+    category, stock status, location, and active state.
+    """
+
+    template_name = "inventory/low_stock_alerts.html"
+    context_object_name = "products"
+    paginate_by = 25
+    page_title = "Low Stock Alerts"
+    header_icon = "warning"
+
+    def get_queryset(self):
+        """Return low-stock products, applying any active filters."""
+        qs = Product.objects.low_stock().select_related("category")
+        self.filterset = ProductFilterSet(self.request.GET, queryset=qs)
+        return self.filterset.qs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["filterset"] = self.filterset
+        context["total_count"] = self.filterset.qs.count()
+        return context

--- a/inventory/wagtail_hooks.py
+++ b/inventory/wagtail_hooks.py
@@ -1,0 +1,33 @@
+"""Wagtail hooks for the inventory app.
+
+Registers admin menu items and URL routes for custom inventory views.
+"""
+
+from django.urls import path, reverse
+from wagtail import hooks
+from wagtail.admin.menu import MenuItem
+
+from inventory.views import LowStockAlertView
+
+
+@hooks.register("register_admin_urls")
+def register_inventory_admin_urls():
+    """Register custom inventory URLs under the Wagtail admin."""
+    return [
+        path(
+            "inventory/low-stock/",
+            LowStockAlertView.as_view(),
+            name="inventory_low_stock",
+        ),
+    ]
+
+
+@hooks.register("register_admin_menu_item")
+def register_low_stock_menu_item():
+    """Add a 'Low Stock Alerts' link to the Wagtail admin sidebar."""
+    return MenuItem(
+        "Low Stock",
+        reverse("inventory_low_stock"),
+        icon_name="warning",
+        order=900,
+    )


### PR DESCRIPTION
Add a dedicated low-stock alerts view in the Wagtail admin with filterable product listings and a sidebar menu item.

Product queryset (inventory/models/product.py):
- ProductQuerySet with low_stock(), out_of_stock(), and in_stock() methods using F() expressions and distinct() queries.
- Attached to Product via objects = ProductQuerySet.as_manager().
- Products with reorder_point=0 are excluded from alerts.

Filterset (inventory/filters.py):
- ProductFilterSet with django-filter providing:
  - category (ModelChoiceFilter)
  - stock_status (custom StockStatusFilter: all/low/in-stock/out-of-stock)
  - is_active (BooleanFilter)
  - location (ModelChoiceFilter on stock_records__location)

View (inventory/views.py):
- LowStockAlertView — class-based (OOP standard), extends WagtailAdminTemplateMixin + ListView for consistent admin chrome.
- Paginated (25 per page), filterable, with select_related for performance.

Template (inventory/templates/inventory/low_stock_alerts.html):
- Extends wagtailadmin/generic/base.html for native admin styling.
- Filter form, results table with SKU links, stock details per location, low/out-of-stock status badges, and pagination.

Hooks (inventory/wagtail_hooks.py):
- register_admin_urls: /admin/inventory/low-stock/
- register_admin_menu_item: 'Low Stock' sidebar link with warning icon.

Closes #21