### PR TITLE
feat: add admin-only inventory search view

### DIFF
--- a/inventory/templates/inventory/search.html
+++ b/inventory/templates/inventory/search.html
@@ -1,0 +1,113 @@
+{% extends "wagtailadmin/generic/base.html" %}
+{% load wagtailadmin_tags i18n %}
+
+{% block main_content %}
+<form method="get" class="w-mb-6">
+    <div style="display: flex; gap: 0.5rem; align-items: center;">
+        <input type="text"
+               name="q"
+               value="{{ search_query }}"
+               placeholder="Search products, categories, locations…"
+               style="flex: 1;"
+               autofocus>
+        <button type="submit" class="button">Search</button>
+    </div>
+</form>
+
+{% if search_query %}
+
+{# ── Products ── #}
+<section class="w-mb-8">
+    <h2>Products ({{ product_results|length }})</h2>
+    {% if product_results %}
+    <table class="listing">
+        <thead>
+            <tr>
+                <th>SKU</th>
+                <th>Name</th>
+                <th>Category</th>
+                <th>Unit Cost</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for product in product_results %}
+            <tr>
+                <td>
+                    <a href="{% url 'wagtailsnippets_inventory_product:edit' product.pk %}">
+                        {{ product.sku }}
+                    </a>
+                </td>
+                <td>{{ product.name }}</td>
+                <td>{{ product.category|default:"—" }}</td>
+                <td>{{ product.unit_cost }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p>{% trans "No matching products." %}</p>
+    {% endif %}
+</section>
+
+{# ── Categories ── #}
+<section class="w-mb-8">
+    <h2>Categories ({{ category_results|length }})</h2>
+    {% if category_results %}
+    <table class="listing">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Slug</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for cat in category_results %}
+            <tr>
+                <td>
+                    <a href="{% url 'wagtailsnippets_inventory_category:edit' cat.pk %}">
+                        {{ cat.name }}
+                    </a>
+                </td>
+                <td>{{ cat.slug }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p>{% trans "No matching categories." %}</p>
+    {% endif %}
+</section>
+
+{# ── Stock Locations ── #}
+<section class="w-mb-8">
+    <h2>Locations ({{ location_results|length }})</h2>
+    {% if location_results %}
+    <table class="listing">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for loc in location_results %}
+            <tr>
+                <td>
+                    <a href="{% url 'wagtailsnippets_inventory_stocklocation:edit' loc.pk %}">
+                        {{ loc.name }}
+                    </a>
+                </td>
+                <td>{{ loc.description|default:"—"|truncatewords:15 }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p>{% trans "No matching locations." %}</p>
+    {% endif %}
+</section>
+
+{% elif not search_query %}
+<p>{% trans "Enter a search term above to find products, categories, and stock locations." %}</p>
+{% endif %}
+{% endblock %}

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -4,11 +4,12 @@ All views follow the project's OOP standard — class-based with
 WagtailAdminTemplateMixin for consistent admin chrome.
 """
 
-from django.views.generic import ListView
+from django.views.generic import ListView, TemplateView
 from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
+from wagtail.search.backends import get_search_backend
 
 from inventory.filters import ProductFilterSet
-from inventory.models import Product
+from inventory.models import Category, Product, StockLocation
 
 
 class LowStockAlertView(WagtailAdminTemplateMixin, ListView):
@@ -35,4 +36,40 @@ class LowStockAlertView(WagtailAdminTemplateMixin, ListView):
         context = super().get_context_data(**kwargs)
         context["filterset"] = self.filterset
         context["total_count"] = self.filterset.qs.count()
+        return context
+
+
+class InventorySearchView(WagtailAdminTemplateMixin, TemplateView):
+    """Unified search across all inventory models (admin-only).
+
+    Searches Products, Categories, and StockLocations using the Wagtail
+    search backend.  Only active items are returned.  Results are grouped
+    by model type for clarity.
+    """
+
+    template_name = "inventory/search.html"
+    page_title = "Inventory Search"
+    header_icon = "search"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        query = self.request.GET.get("q", "").strip()
+        context["search_query"] = query
+
+        if query:
+            backend = get_search_backend()
+            context["product_results"] = backend.search(
+                query, Product.objects.filter(is_active=True),
+            )
+            context["category_results"] = backend.search(
+                query, Category.objects.filter(is_active=True),
+            )
+            context["location_results"] = backend.search(
+                query, StockLocation.objects.filter(is_active=True),
+            )
+        else:
+            context["product_results"] = Product.objects.none()
+            context["category_results"] = Category.objects.none()
+            context["location_results"] = StockLocation.objects.none()
+
         return context

--- a/inventory/wagtail_hooks.py
+++ b/inventory/wagtail_hooks.py
@@ -7,7 +7,7 @@ from django.urls import path, reverse
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 
-from inventory.views import LowStockAlertView
+from inventory.views import InventorySearchView, LowStockAlertView
 
 
 @hooks.register("register_admin_urls")
@@ -18,6 +18,11 @@ def register_inventory_admin_urls():
             "inventory/low-stock/",
             LowStockAlertView.as_view(),
             name="inventory_low_stock",
+        ),
+        path(
+            "inventory/search/",
+            InventorySearchView.as_view(),
+            name="inventory_search",
         ),
     ]
 
@@ -30,4 +35,15 @@ def register_low_stock_menu_item():
         reverse("inventory_low_stock"),
         icon_name="warning",
         order=900,
+    )
+
+
+@hooks.register("register_admin_menu_item")
+def register_inventory_search_menu_item():
+    """Add an 'Inventory Search' link to the Wagtail admin sidebar."""
+    return MenuItem(
+        "Inventory Search",
+        reverse("inventory_search"),
+        icon_name="search",
+        order=850,
     )


### PR DESCRIPTION
Add a unified search view in the Wagtail admin that queries Products, Categories, and StockLocations using the Wagtail search backend.  Only active items are returned.  Results are grouped by model type with links to the corresponding Wagtail snippet edit pages.

This is an admin/staff-only feature — the public search/views.py is left unchanged (it only covers Wagtail Pages).

View (inventory/views.py):
- InventorySearchView — class-based (OOP standard), extends WagtailAdminTemplateMixin + TemplateView.
- Uses get_search_backend() to search across all three models.
- Filters by is_active=True on each model.

Template (inventory/templates/inventory/search.html):
- Extends wagtailadmin/generic/base.html for native admin styling.
- Search form with autofocus, results tables grouped by model type (Products, Categories, Locations), result counts, edit links.

Hooks (inventory/wagtail_hooks.py):
- register_admin_urls: /admin/inventory/search/
- register_admin_menu_item: 'Inventory Search' sidebar link with search icon (order=850).

Closes #23