### PR TITLE
test: unique factory usernames and audit tenant isolation

### DIFF
--- a/inventory/models/product.py
+++ b/inventory/models/product.py
@@ -10,6 +10,7 @@ from wagtail.fields import RichTextField
 from wagtail.models import Orderable
 from wagtail.search import index
 from .base import TimeStampedModel
+from tenants.context import get_current_tenant
 
 
 class UnitOfMeasure(models.TextChoices):
@@ -32,7 +33,6 @@ class ProductQuerySet(models.QuerySet):
 
     def filter_by_current_tenant(self):
         """Filter to thread-local tenant; empty queryset if unset (same contract as ``TimeStampedModel`` managers)."""
-        from tenants.context import get_current_tenant
 
         current_tenant = get_current_tenant()
         if current_tenant is None:

--- a/inventory/services/audit.py
+++ b/inventory/services/audit.py
@@ -15,6 +15,7 @@ import logging
 from typing import Any
 
 from inventory.models.audit import ComplianceAuditLog
+from tenants.middleware import get_effective_tenant
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +114,6 @@ class AuditService:
         ComplianceAuditLog
             The persisted audit log entry.
         """
-        from tenants.middleware import get_effective_tenant
 
         tenant = getattr(request, "tenant", None) or get_effective_tenant(request)
         user = getattr(request, "user", None)

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -34,8 +34,10 @@ def create_tenant(name=None, slug=None, **kwargs):
     return tenant
 
 
-def create_user(username="testuser", password="testpass123", **kwargs):
-    """Create a test user."""
+def create_user(username=None, password="testpass123", **kwargs):
+    """Create a test user. Username defaults to a unique value per call."""
+    if username is None:
+        username = f"user_{uuid.uuid4().hex[:12]}"
     defaults = {
         "username": username,
         "email": f"{username}@test.com",
@@ -46,8 +48,10 @@ def create_user(username="testuser", password="testpass123", **kwargs):
     return user
 
 
-def create_admin_user(username="admin", password="admin123", **kwargs):
-    """Create a test superuser."""
+def create_admin_user(username=None, password="admin123", **kwargs):
+    """Create a test superuser. Username defaults to a unique value per call."""
+    if username is None:
+        username = f"admin_{uuid.uuid4().hex[:12]}"
     defaults = {
         "username": username,
         "email": f"{username}@test.com",

--- a/tests/inventory/factories.py
+++ b/tests/inventory/factories.py
@@ -28,8 +28,10 @@ from tenants.models import Tenant
 User = get_user_model()
 
 
-def create_user(*, username="testuser", password="testpass123", **kwargs):
-    """Create and return a Django user."""
+def create_user(*, username=None, password="testpass123", **kwargs):
+    """Create and return a Django user. Username defaults to a unique value per call."""
+    if username is None:
+        username = f"user_{uuid.uuid4().hex[:12]}"
     defaults = {
         "username": username,
         "password": password,
@@ -41,12 +43,14 @@ def create_user(*, username="testuser", password="testpass123", **kwargs):
     return user
 
 
-def create_admin_user(*, username="admin", password="adminpass123", **kwargs):
-    """Create and return a Django superuser."""
+def create_admin_user(*, username=None, password="adminpass123", **kwargs):
+    """Create and return a Django superuser. Username defaults to a unique value per call."""
+    if username is None:
+        username = f"admin_{uuid.uuid4().hex[:12]}"
     defaults = {
         "username": username,
         "password": password,
-        "email": "admin@example.com",
+        "email": f"{username}@example.com",
     }
     defaults.update(kwargs)
     password = defaults.pop("password")

--- a/tests/inventory/test_services/test_audit_service.py
+++ b/tests/inventory/test_services/test_audit_service.py
@@ -16,6 +16,7 @@ from inventory.models import MovementType
 from inventory.models.audit import AuditAction, ComplianceAuditLog
 from inventory.services.audit import AuditService
 from inventory.services.stock import StockService
+from tenants.context import clear_current_tenant
 
 from ..factories import (
     create_location,
@@ -203,7 +204,8 @@ class AuditServiceLogFromRequestTests(TestCase):
         self.assertEqual(entry.details["operation"], "import")
 
     def test_missing_tenant_on_request(self):
-        """When request has no tenant attr, None is passed to log()."""
+        """With no request.tenant and no thread-local tenant, log() gets tenant=None."""
+        clear_current_tenant()
         request = SimpleNamespace(
             user=self.user,
             META={"REMOTE_ADDR": "10.0.0.1"},


### PR DESCRIPTION
- Default create_user/create_admin_user to unique usernames in shared and inventory factories; derive admin email from username in inventory factories.

- Call clear_current_tenant in audit missing-tenant test so thread-local tenant does not leak between tests.

- Hoist get_current_tenant and get_effective_tenant imports to module level in Product and AuditService.

Made-with: Cursor

## Description

<!-- What does this change do? Please provide a concise summary focusing on the "why" as well as the "what". -->

## Related Issue(s)

<!-- Link related issues here. Use closing keywords when appropriate. -->

- Closes #
- Related to #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Checklist for Contributors

- [ ] Tests added or updated as needed
- [ ] `python manage.py test` passes locally
- [ ] `python manage.py check` reports no issues
- [ ] `python manage.py makemigrations --check --dry-run` shows no missing migrations
- [ ] Code style and linting (`ruff check .`) pass locally (if configured)
- [ ] Documentation updated where relevant (`README.md`, `CONTRIBUTING.md`, `docs/*.md`)

