### PR TITLE
Add phone number validation for customers and suppliers

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,7 @@
 - [Common Workflows](#common-workflows)
 - [Endpoint Reference](#endpoint-reference)
 - [Error Handling](#error-handling)
+- [Phone Number Validation](#phone-number-validation)
 - [Pagination & Filtering](#pagination--filtering)
 - [Rate Limiting](#rate-limiting)
 
@@ -398,6 +399,27 @@ curl -X POST http://localhost:8000/api/v1/products/ \
 }
 ```
 
+### Phone Number Validation
+
+Customer and Supplier phone fields validate phone number formats at the API level. Valid phone numbers may include an optional country code, spaces, hyphens, and parentheses.
+
+Examples of accepted formats:
+
+```text
+9876543210
++919876543210
++91 98765 43210
+98765-43210
+(123) 456-7890
+```
+
+Invalid phone values return a `400` validation error:
+
+```json
+{
+  "phone": ["Enter a valid phone number."]
+}
+```
 ---
 
 ## Pagination & Filtering

--- a/src/api/serializers/procurement.py
+++ b/src/api/serializers/procurement.py
@@ -20,6 +20,7 @@ from tenants.middleware import get_effective_tenant
 from api.serializers.translatable_representation import TranslatableRepresentationMixin
 from api.serializers.translatable_writable import TranslatableWritableMixin
 
+from api.validators import validate_phone_number
 
 class SupplierSerializer(
     TranslatableWritableMixin,
@@ -59,6 +60,10 @@ class SupplierSerializer(
             raise serializers.ValidationError(
                 "A supplier with this code already exists for this tenant."
             )
+        return value
+
+    def validate_phone(self, value):
+        validate_phone_number(value)
         return value
 
 

--- a/src/api/serializers/sales.py
+++ b/src/api/serializers/sales.py
@@ -21,6 +21,7 @@ from tenants.middleware import get_effective_tenant
 from api.serializers.translatable_representation import TranslatableRepresentationMixin
 from api.serializers.translatable_writable import TranslatableWritableMixin
 
+from api.validators import validate_phone_number
 
 def _derived_warehouse_from_sales_order(sales_order):
     """Derive facility warehouse from dispatches when unambiguous.
@@ -98,6 +99,10 @@ class CustomerSerializer(
             raise serializers.ValidationError(
                 "A customer with this code already exists for this tenant."
             )
+        return value
+
+    def validate_phone(self, value):
+        validate_phone_number(value)
         return value
 
     def create(self, validated_data):

--- a/src/api/validators.py
+++ b/src/api/validators.py
@@ -1,0 +1,18 @@
+import re
+from django.core.exceptions import ValidationError
+
+
+PHONE_NUMBER_REGEX = re.compile(r"^\+?[0-9\s\-()]{7,20}$")
+
+
+def validate_phone_number(value):
+    """
+    Validate phone numbers with patterns that include optional country code, spaces,hyphens, and parentheses.
+    """
+    if value in (None, ""):
+        return
+
+    if not PHONE_NUMBER_REGEX.fullmatch(value):
+        raise ValidationError(
+            "Enter a valid phone number."
+        )

--- a/tests/api/test_validators.py
+++ b/tests/api/test_validators.py
@@ -1,27 +1,31 @@
-import pytest
 from django.core.exceptions import ValidationError
+from django.test import SimpleTestCase
 
-from api.validators import validate_phone_number
-
-
-@pytest.mark.parametrize("phone", [
-    "9876543210",
-    "+919876543210",
-    "+91 98765 43210",
-    "98765-43210",
-])
-
-def test_valid_phone_numbers(phone):
-    validate_phone_number(phone)
+from src.api.validators import validate_phone_number
 
 
-@pytest.mark.parametrize("phone", [
-    "abc123",
-    "123",
-    "phone-number",
-    "!!!!",
-])
+class PhoneNumberValidatorTests(SimpleTestCase):
+    def test_valid_phone_numbers(self):
+        valid_numbers = [
+            "9876543210",
+            "+919876543210",
+            "+91 98765 43210",
+            "98765-43210",
+        ]
 
-def test_invalid_phone_numbers(phone):
-    with pytest.raises(ValidationError):
-        validate_phone_number(phone)
+        for phone in valid_numbers:
+            with self.subTest(phone=phone):
+                validate_phone_number(phone)
+
+    def test_invalid_phone_numbers(self):
+        invalid_numbers = [
+            "abc123",
+            "123",
+            "phone-number",
+            "!!!!",
+        ]
+
+        for phone in invalid_numbers:
+            with self.subTest(phone=phone):
+                with self.assertRaises(ValidationError):
+                    validate_phone_number(phone)

--- a/tests/api/test_validators.py
+++ b/tests/api/test_validators.py
@@ -1,0 +1,27 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from api.validators import validate_phone_number
+
+
+@pytest.mark.parametrize("phone", [
+    "9876543210",
+    "+919876543210",
+    "+91 98765 43210",
+    "98765-43210",
+])
+
+def test_valid_phone_numbers(phone):
+    validate_phone_number(phone)
+
+
+@pytest.mark.parametrize("phone", [
+    "abc123",
+    "123",
+    "phone-number",
+    "!!!!",
+])
+
+def test_invalid_phone_numbers(phone):
+    with pytest.raises(ValidationError):
+        validate_phone_number(phone)


### PR DESCRIPTION
## Description

Added phone number validation for Customer and Supplier API serializers.

This change introduces a reusable phone number validator in `src/api/validators.py` and applies it to customer and supplier phone fields at the API level. The validator rejects invalid phone formats and returns clear validation error messages.

Tests were added for valid and invalid phone number formats, and the API documentation was updated accordingly.

## Related Issue(s)

-Closes #128 
- Related to #128 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactor / chore

## Checklist for Contributors

- [x] Tests added or updated as needed
- [x] `python manage.py test` passes locally
- [x] `python manage.py check` reports no issues
- [x] `python manage.py makemigrations --check --dry-run` shows no missing migrations
- [x] Code style and linting (`ruff check .`) pass locally (if configured)
- [ ] Documentation updated where relevant (`README.md`, `CONTRIBUTING.md`, `docs/*.md`)