### PR TITLE
fx: Fix JWT authentication 401 errors on production deployment #166

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update --yes --quiet && apt-get install --yes --quiet --no-install-r
     libjpeg62-turbo-dev \
     zlib1g-dev \
     libwebp-dev \
+    curl \
  && rm -rf /var/lib/apt/lists/*
 
 # Install the project requirements (includes gunicorn).
@@ -52,6 +53,11 @@ WORKDIR /app/src
 RUN DJANGO_SETTINGS_MODULE=the_inventory.settings.production \
     SECRET_KEY=collectstatic-build-only-not-used-at-runtime \
     python manage.py collectstatic --noinput --clear
+
+# Health check for container orchestration (Render, K8s, etc.)
+# Verifies the app is responding to requests on the configured PORT
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:${PORT:-8000}/api/v1/ || exit 1
 
 # Runtime command that executes when "docker run" is called.
 # entrypoint.sh: migrate → optional seed (env AUTO_SEED_DATABASE / SEED_*) → gunicorn.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -136,16 +136,37 @@ docker-compose up -d
 
 In Render dashboard, add these environment variables:
 
+**Required Variables:**
 ```
 DEBUG=False
 DJANGO_SETTINGS_MODULE=the_inventory.settings.production
 SECRET_KEY=<generate-and-paste>
 ALLOWED_HOSTS=your-service.onrender.com
 DATABASE_URL=<PostgreSQL-connection-string>
-REDIS_URL=<Redis-connection-string>
-FRONTEND_URL=https://your-frontend.vercel.app
-CORS_ALLOWED_ORIGINS=https://your-frontend.vercel.app
 ```
+
+**Critical for JWT Authentication (MUST SET - prevents 401 errors):**
+```
+CORS_ALLOWED_ORIGINS=https://your-frontend.vercel.app
+FRONTEND_URL=https://your-frontend.vercel.app
+CSRF_TRUSTED_ORIGINS=https://your-frontend.vercel.app
+```
+
+**JWT Cookie Configuration:**
+```
+JWT_COOKIE_SECURE=true
+JWT_COOKIE_SAMESITE=Lax
+JWT_COOKIE_DOMAIN=
+```
+
+**Optional but Recommended:**
+```
+REDIS_URL=<Redis-connection-string>
+DJANGO_LOG_LEVEL=INFO
+AUTO_SEED_DATABASE=false
+```
+
+**⚠️ Important:** If you skip the "Critical for JWT Authentication" variables, users will get `401 Unauthorized` errors after login. See [Troubleshooting Guide](troubleshooting.md#jwt-authentication-401-errors-production) for details.
 
 ### 4. Create PostgreSQL Database
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -76,6 +76,52 @@ python manage.py seed_database --create-default
 
 ---
 
+## JWT Authentication 401 Errors (Production)
+
+**Symptom:** Login works but subsequent requests fail with `401 Unauthorized`
+
+**Most Common Cause:** Missing environment variables on Render (or other production platform)
+
+**Solution:**
+
+1. **Check Render Environment Variables:**
+   - Go to Render Dashboard → Your Web Service → Environment
+   - Verify these variables are set:
+     - `CORS_ALLOWED_ORIGINS` — Must include your frontend URL
+     - `FRONTEND_URL` — Must match your frontend domain
+     - `CSRF_TRUSTED_ORIGINS` — Must match your frontend domain
+
+2. **Verify Frontend URL:**
+   - Frontend: `https://your-frontend.vercel.app`
+   - Backend: `https://your-service.onrender.com`
+   - These should be different domains (that's normal)
+
+3. **Check Browser DevTools:**
+   - Open DevTools → Application → Cookies
+   - After login, verify `access_token` and `refresh_token` cookies are present
+   - If cookies are missing, the issue is cookie configuration
+   - If cookies are present but requests still fail, the issue is CORS
+
+4. **Check Network Tab:**
+   - Look at the failed request to `/api/v1/auth/me/`
+   - Check Response Headers for `Set-Cookie` headers
+   - Check Request Headers for `Cookie` header
+   - If `Cookie` header is missing, cookies aren't being sent
+
+5. **Common Causes:**
+   - `CORS_ALLOWED_ORIGINS` not set or incorrect
+   - `FRONTEND_URL` not set
+   - `CSRF_TRUSTED_ORIGINS` not set
+   - Frontend not sending credentials with requests
+   - Domain mismatch between frontend and backend
+
+**Still not working?**
+- See [Environment Configuration Guide](environment.md#jwt-cookie-configuration) for detailed JWT cookie settings
+- Check [Deployment Guide](deployment.md#render-deployment) for complete Render setup
+- Check [Architecture Guide](architecture.md) for JWT authentication flow details
+
+---
+
 ## Development Environment
 
 **Port already in use:**

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,8 +10,35 @@ export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE:-the_inventory.settings.
 export DATABASE_URL="${DATABASE_URL}"
 export PORT="${PORT:-8000}"
 
+# Validate critical environment variables
+_validate_env() {
+  local var=$1
+  local is_required=$2
+  local value="${!var}"
+  
+  if [ -z "$value" ]; then
+    if [ "$is_required" = "true" ]; then
+      echo "ERROR: Required environment variable '$var' is not set"
+      exit 1
+    else
+      echo "WARNING: Optional environment variable '$var' is not set"
+    fi
+  fi
+}
+
 # Log safe startup context without leaking credentials.
 echo "=== Startup Environment Status ==="
+
+# Validate required variables (fail if missing)
+_validate_env "SECRET_KEY" "true"
+_validate_env "ALLOWED_HOSTS" "true"
+_validate_env "DATABASE_URL" "true"
+
+# Validate recommended variables (warn but don't fail)
+_validate_env "CORS_ALLOWED_ORIGINS" "false"
+_validate_env "FRONTEND_URL" "false"
+_validate_env "CSRF_TRUSTED_ORIGINS" "false"
+
 echo "DJANGO_SETTINGS_MODULE loaded"
 if [ -n "${DATABASE_URL:-}" ]; then
   echo "DATABASE_URL loaded"
@@ -60,9 +87,19 @@ case "$_auto_seed" in
 esac
 
 # Start Gunicorn (access + error logs to stdout/stderr for platform log drains)
+# Configuration tuned for production:
+#   --workers 4: Appropriate for small-medium deployments
+#   --worker-class sync: Synchronous workers (suitable for I/O-bound Django)
+#   --max-requests 1000: Recycle workers every 1000 requests to prevent memory leaks
+#   --max-requests-jitter 100: Stagger worker recycling to avoid simultaneous restarts
+#   --timeout 60: Request timeout (increased from default 30s for longer operations)
 exec gunicorn the_inventory.wsgi:application \
   --bind "[::]:$PORT" \
   --workers 4 \
+  --worker-class sync \
+  --max-requests 1000 \
+  --max-requests-jitter 100 \
+  --timeout 60 \
   --access-logfile - \
   --error-logfile - \
   --log-level info \


### PR DESCRIPTION
This PR fix the following error:

Login works successfully on local development but fails on production deployment with 401 Unauthorized errors:

```
WARNING 2026-05-17 18:12:15,658 django.request Unauthorized: /api/v1/auth/me/
::1 - - [17/May/2026:18:12:15 +0000] "GET /api/v1/auth/me/?language=en HTTP/1.1" 401 58
```
The issue appears to be related to CORS or cookie configuration differences between local and production environments.

