### PR TITLE
Fix: Change entrypoint.sh shebang from sh to bash for Render compatib…

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -xe
 
 # Django lives in src/ (repo root is parent of this script in Docker: /app).


### PR DESCRIPTION
## Overview:

The entrypoint.sh script used #!/bin/sh (POSIX shell) but contained bash-specific syntax (indirect variable expansion: ${!var}). This caused 'Bad substitution' errors when deployed to Render, which uses Debian-based Docker images where /bin/sh is a POSIX shell (ash), not bash.

### ROOT CAUSE:
- Line 17 of entrypoint.sh uses: local value="${!var}"
- This is bash-specific indirect variable expansion
- POSIX sh (ash) doesn't support this syntax
- Error occurred during environment variable validation in _validate_env()

### SOLUTION:
Changed shebang from #!/bin/sh to #!/bin/bash

### WHY THIS WORKS:
- Dockerfile uses python:3.12-slim-bookworm (Debian-based, not Alpine)
- Debian includes bash by default
- /bin/bash is available in the container
- Bash supports all the syntax used in the script
- No code changes needed, only shebang change

### VERIFICATION:
- Script tested locally with bash
- Indirect variable expansion ${!var} works correctly
- Environment validation function works as intended
- No breaking changes to script logic

### IMPACT:
- Fixes container startup failure on Render
- Enables environment variable validation
- Allows deployment to proceed successfully
- Exit code changes from 2 (error) to 0 (success)

Related to: Issue #166 (JWT authentication 401 errors)
