### PR TITLE
Potential fix for code scanning alert no. 43: Information exposure through an exception

### DIFF
--- a/src/api/authentication.py
+++ b/src/api/authentication.py
@@ -28,8 +28,8 @@ class CookieJWTAuthentication(JWTAuthentication):
         """Validate JWT token with proper error handling."""
         try:
             return super().get_validated_token(raw_token)
-        except InvalidToken as e:
-            raise InvalidToken(f"Invalid token: {str(e)}")
+        except InvalidToken:
+            raise InvalidToken("Invalid token")
 
     def extract_token_from_cookie(self, request):
         """Extract JWT token from HttpOnly cookie.


### PR DESCRIPTION
Potential fix for [https://github.com/Ndevu12/the_inventory/security/code-scanning/43](https://github.com/Ndevu12/the_inventory/security/code-scanning/43)

Use a generic error message when re-raising `InvalidToken`, and avoid embedding `str(e)` in the exception text. This preserves behavior (still raises `InvalidToken` for invalid tokens) while preventing internal detail leakage.

Best fix in `src/api/authentication.py`:
- In `get_validated_token` (around lines 29–33), change the `except InvalidToken as e:` block to either:
  - catch as `except InvalidToken:` and raise `InvalidToken("Invalid token")`, or
  - keep `as e` but do not use `e` in the message.
- No additional imports or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
