### PR TITLE
Potential fix for code scanning alert no. 35: Information exposure through an exception

### DIFF
--- a/src/api/views/reservation.py
+++ b/src/api/views/reservation.py
@@ -95,14 +95,14 @@ class StockReservationViewSet(TranslatableAPIReadMixin,
                 reserved_by=reserved_by,
                 notes=data.get("notes", ""),
             )
-        except InsufficientStockError as e:
+        except InsufficientStockError:
             return Response(
-                {"detail": str(e)},
+                {"detail": "Insufficient stock to complete this reservation."},
                 status=status.HTTP_409_CONFLICT,
             )
-        except (ValueError, InventoryError) as e:
+        except (ValueError, InventoryError):
             return Response(
-                {"detail": str(e)},
+                {"detail": "Unable to create reservation with the provided data."},
                 status=status.HTTP_422_UNPROCESSABLE_ENTITY,
             )
 
@@ -120,14 +120,14 @@ class StockReservationViewSet(TranslatableAPIReadMixin,
 
         try:
             service.fulfill_reservation(reservation, created_by=created_by)
-        except ReservationConflictError as e:
+        except ReservationConflictError:
             return Response(
-                {"detail": str(e)},
+                {"detail": "Reservation cannot be fulfilled in its current state."},
                 status=status.HTTP_409_CONFLICT,
             )
-        except InsufficientStockError as e:
+        except InsufficientStockError:
             return Response(
-                {"detail": str(e)},
+                {"detail": "Insufficient stock to fulfill this reservation."},
                 status=status.HTTP_409_CONFLICT,
             )
 
@@ -145,9 +145,9 @@ class StockReservationViewSet(TranslatableAPIReadMixin,
 
         try:
             service.cancel_reservation(reservation)
-        except ReservationConflictError as e:
+        except ReservationConflictError:
             return Response(
-                {"detail": str(e)},
+                {"detail": "Reservation cannot be canceled in its current state."},
                 status=status.HTTP_409_CONFLICT,
             )
 


### PR DESCRIPTION
Potential fix for [https://github.com/Ndevu12/the_inventory/security/code-scanning/35](https://github.com/Ndevu12/the_inventory/security/code-scanning/35)

The best fix is to stop returning raw exception messages to clients and instead return a **generic, client-safe message**, while preserving status codes and behavior.  
In `src/api/views/reservation.py`, replace `{"detail": str(e)}` in exception handlers with fixed strings that describe the error category without exposing internals.

Single best minimal fix (without changing functionality):  
- Keep existing exception handling and HTTP status codes unchanged.
- Only replace response detail text in caught exceptions with generic messages.
- No new imports/dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
