### PR TITLE
Potential fix for code scanning alert no. 30: Information exposure through an exception

### DIFF
--- a/src/api/views/inventory.py
+++ b/src/api/views/inventory.py
@@ -532,9 +532,9 @@ class StockMovementViewSet(TranslatableAPIReadMixin,
                 {"detail": str(e)},
                 status=status.HTTP_409_CONFLICT,
             )
-        except InventoryError as e:
+        except InventoryError:
             return Response(
-                {"detail": str(e)},
+                {"detail": "Unable to process stock movement."},
                 status=status.HTTP_422_UNPROCESSABLE_ENTITY,
             )
         except DjangoValidationError:


### PR DESCRIPTION
Potential fix for [https://github.com/Ndevu12/the_inventory/security/code-scanning/30](https://github.com/Ndevu12/the_inventory/security/code-scanning/30)

Use a safe, generic API error response in the `except InventoryError` handler, and avoid exposing `str(e)` to clients. Keep status code and behavior the same to avoid functional change for API consumers.  
Best fix here: in `src/api/views/inventory.py` within `StockMovementViewSet.create`, replace the `except InventoryError as e` block with `except InventoryError:` and return a generic message like `"Unable to process stock movement."` with HTTP 422.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
