### PR TITLE
Potential fix for code scanning alert no. 28: Information exposure through an exception

### DIFF
--- a/src/api/views/cycle.py
+++ b/src/api/views/cycle.py
@@ -168,7 +168,11 @@ class InventoryCycleViewSet(TranslatableAPIReadMixin,
         try:
             service.complete_cycle(cycle)
         except ValueError as e:
-            return Response({"detail": str(e)}, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
+            logger.warning("Failed to complete inventory cycle %s: %s", cycle.id, e, exc_info=True)
+            return Response(
+                {"detail": "Unable to complete this cycle."},
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
 
         cycle.refresh_from_db()
         output = InventoryCycleDetailSerializer(


### PR DESCRIPTION
Potential fix for [https://github.com/Ndevu12/the_inventory/security/code-scanning/28](https://github.com/Ndevu12/the_inventory/security/code-scanning/28)

Use a generic client-facing error message and log exception details on the server.  
Best fix (without changing endpoint behavior/status code): in `src/api/views/cycle.py`, update the `complete` method’s `except ValueError as e` block to:
- log the exception with context (`cycle.id`) and `exc_info=True`,
- return a fixed message like `"Unable to complete this cycle."` with HTTP 422.

This preserves response status and control flow, avoids leaking internals, and keeps diagnostics in server logs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
