### PR TITLE
Potential fix for code scanning alert no. 44: Information exposure through an exception

### DIFF
--- a/src/api/views/inventory.py
+++ b/src/api/views/inventory.py
@@ -1,5 +1,7 @@
 """API views for inventory models."""
 
+import logging
+
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import IntegrityError
 from django.db.models import Count
@@ -51,6 +53,9 @@ from api.serializers.inventory import (
     WarehouseSerializer,
 )
 from api.views.reservation import product_availability_action
+
+
+logger = logging.getLogger(__name__)
 
 
 class TenantScopedInventoryMixin:
@@ -528,8 +533,9 @@ class StockMovementViewSet(TranslatableAPIReadMixin,
                     created_by=created_by,
                 )
         except (InsufficientStockError, MovementImmutableError) as e:
+            logger.warning("Stock movement conflict: %s", e, exc_info=True)
             return Response(
-                {"detail": str(e)},
+                {"detail": "Unable to process stock movement due to a conflict."},
                 status=status.HTTP_409_CONFLICT,
             )
         except InventoryError:


### PR DESCRIPTION
Potential fix for [https://github.com/Ndevu12/the_inventory/security/code-scanning/44](https://github.com/Ndevu12/the_inventory/security/code-scanning/44)

Use a generic conflict message in the HTTP response instead of `str(e)`, and keep exception details only in server logs.

Best fix in this file:
- In `src/api/views/inventory.py`, add Python’s standard `logging` import.
- Define a module logger (`logger = logging.getLogger(__name__)`) near imports.
- Update the `except (InsufficientStockError, MovementImmutableError) as e:` block to log the exception (`logger.warning(..., exc_info=True)`) and return a generic `"detail"` message for clients.

This preserves functionality (still returns 409 for these conflicts) while removing exception-detail exposure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
