### PR TITLE
Potential fix for code scanning alert no. 27: Information exposure through an exception

### DIFF
--- a/src/api/views/cycle.py
+++ b/src/api/views/cycle.py
@@ -151,7 +151,11 @@ class InventoryCycleViewSet(TranslatableAPIReadMixin,
                 notes=data.get("notes", ""),
             )
         except ValueError as e:
-            return Response({"detail": str(e)}, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
+            logger.warning("Failed to record count for inventory cycle %s: %s", cycle.id, e, exc_info=True)
+            return Response(
+                {"detail": "Unable to record count for this cycle."},
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
 
         cycle.refresh_from_db()
         output = InventoryCycleDetailSerializer(


### PR DESCRIPTION
Potential fix for [https://github.com/Ndevu12/the_inventory/security/code-scanning/27](https://github.com/Ndevu12/the_inventory/security/code-scanning/27)

Use safe exception handling in `record_count` by avoiding direct exposure of `str(e)` in the API response.  
Best fix (without changing endpoint behavior materially): keep returning HTTP 422 for business failure, but replace the response detail with a generic message and log the exception server-side with `exc_info=True`.

Change region:
- `src/api/views/cycle.py`, `record_count` method, `except ValueError as e` block around lines 153–154.

No new imports or dependencies are needed because `logger` is already defined in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
