### PR TITLE
fix: make gunicorn workers configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@
 #
 # Required variables are marked with [REQUIRED].
 # Optional variables have sensible defaults if not specified.
+
+# Gunicorn worker count for production deployment
+GUNICORN_WORKERS=4
 #
 # =============================================================================
 # CORE SETTINGS

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -553,3 +553,21 @@ python -c "from django.core.management.utils import get_random_secret_key; print
 - **Update regularly** — Keep dependencies updated for security
 
 See [Troubleshooting Guide](troubleshooting.md) for more help.
+
+### Configure Gunicorn Workers
+
+The Gunicorn worker count can be configured using the `GUNICORN_WORKERS` environment variable.
+
+By default, the application uses 4 workers.
+
+Example:
+
+    GUNICORN_WORKERS=4
+
+For smaller deployments, use fewer workers:
+
+    GUNICORN_WORKERS=1
+
+For larger deployments, increase the worker count based on CPU and memory:
+
+    GUNICORN_WORKERS=8

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,14 +88,15 @@ esac
 
 # Start Gunicorn (access + error logs to stdout/stderr for platform log drains)
 # Configuration tuned for production:
-#   --workers 4: Appropriate for small-medium deployments
+#   --workers ${GUNICORN_WORKERS:-4}: Configurable worker count with default 4
 #   --worker-class sync: Synchronous workers (suitable for I/O-bound Django)
 #   --max-requests 1000: Recycle workers every 1000 requests to prevent memory leaks
 #   --max-requests-jitter 100: Stagger worker recycling to avoid simultaneous restarts
 #   --timeout 60: Request timeout (increased from default 30s for longer operations)
+GUNICORN_WORKERS="${GUNICORN_WORKERS:-4}"
 exec gunicorn the_inventory.wsgi:application \
   --bind "[::]:$PORT" \
-  --workers 4 \
+  --workers "$GUNICORN_WORKERS" \
   --worker-class sync \
   --max-requests 1000 \
   --max-requests-jitter 100 \


### PR DESCRIPTION
This PR makes the Gunicorn worker count configurable using the `GUNICORN_WORKERS` environment variable.

Changes made:

- Added `GUNICORN_WORKERS` support in `entrypoint.sh`
- Kept the default worker count as `4`
- Updated `.env.example` with the new environment variable
- Updated `docs/deployment.md` with guidance for configuring worker count

Related Issue:

Closes #162