### PR TITLE
security: auto-remediate worm indicators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,9 +221,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
-branch_structure.json
-temp_auto_push.bat
-temp_interactive_push.bat
 
 # Malware quarantine / remediation artifacts (kept local, never committed)
 .malware-quarantine/


### PR DESCRIPTION
Automated worm remediation for `Ndevu12/the_inventory` by StayAwakeBot Security Sentinel.

## Changes

- `strip-gitignore` — `.gitignore`

## ⚠ Still needs review (not auto-fixed)

These are *suspicious* (heuristic) matches — possibly a legitimate inlined asset/minified file, possibly a payload the confirmed signatures didn't name. Review each; allowlist if legitimate, or remove if not.

- `evil-merge` — `d5d8fd296a`

Originals are recoverable from git history. Evil-merge findings (if any) are reported separately and need a manual history rewrite.

_Review and merge if correct. This is a single rolling PR — re-runs update it rather than opening duplicates._